### PR TITLE
Enable custom sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See `giss --help` for all available options.
 
 ```
 USAGE:
-    giss [FLAGS] [OPTIONS] [target]...
+    giss [FLAGS] [OPTIONS] [--] [target]...
 
 FLAGS:
     -a, --assigned
@@ -76,9 +76,25 @@ OPTIONS:
             Enable or disable output with colors. By default, the application will try to figure out if colors are
             supported by the terminal in the current context, and use it if possible. Possible values are "on", "true",
             "off", "false", "auto". [default: auto]
+    -l, --labels <labels>...
+            Filter by label
+
+            Only include issues, pull requests or review reuests which has (all) the given label(s).
     -n, --limit <limit>
             Limit the number of issues or pull requests to list [default: 10]
 
+    -O, --order <order>
+            Ordering
+
+            Can be either ascending (asc|ascending) or decending (desc|descending)
+    -P, --project <project>
+            Filter by project
+
+            Only include isses, pull request or review requests which is assoicated with the given project.
+    -s, --sort-by <sort-by>
+            Sort by
+
+            Sort by any of the following properties; "created", "updated", "comments", "reactions"
     -t, --token <token>
             GitHub API token
 

--- a/data/graphql/queries/search_issues.graphql
+++ b/data/graphql/queries/search_issues.graphql
@@ -22,7 +22,7 @@ fragment issueFields on Issue {
     issueState: state
     assignees(first: 10) {
         nodes {
-            login
+            ...userFields
         }
     }
     updatedAt
@@ -36,6 +36,9 @@ fragment issueFields on Issue {
         nameWithOwner
     }
     comments {
+        totalCount
+    }
+    reactions {
         totalCount
     }
 }
@@ -50,17 +53,14 @@ fragment pullRequestFields on PullRequest {
     createdAt
     assignees(first: 10) {
         nodes {
-            login
+            ...userFields
         }
     }
     reviewRequests(first: 10) {
         totalCount
         nodes {
-            id
-            pullRequest {
-                author {
-                    login
-                }
+            requestedReviewer {
+                ...userFields
             }
         }
     }
@@ -75,4 +75,12 @@ fragment pullRequestFields on PullRequest {
     comments {
         totalCount
     }
+    reactions {
+        totalCount
+    }
+}
+
+fragment userFields on User {
+    login,
+    id
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -55,6 +55,7 @@ impl From<reqwest::Error> for ApiError {
     }
 }
 
+#[derive(Debug)]
 pub enum ApiError {
     NoResponse(String),
     Response(u16),

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 use crate::{
     args::read_repo_from_file,

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -78,10 +78,14 @@ pub struct Config {
     review_requests: bool,
 
     /// Sort by
+    ///
+    /// Sort by any of the following properties; "created", "updated", "comments", "reactions"
     #[structopt(short, long)]
     sort_by: Option<Property>,
 
     /// Ordering
+    ///
+    /// Can be either ascending (asc|ascending) or decending (desc|descending)
     #[structopt(short = "O", long)]
     order: Option<Order>,
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,6 +1,14 @@
 use std::{fmt::Display, str::FromStr};
 
-use crate::{args::read_repo_from_file, list::StateFilter, project::Project, target::Target, user::Username, AppErr};
+use crate::{
+    args::read_repo_from_file,
+    list::StateFilter,
+    project::Project,
+    sort::{Order, Property, Sorting},
+    target::Target,
+    user::Username,
+    AppErr,
+};
 use structopt::StructOpt;
 use termcolor::ColorChoice;
 
@@ -68,6 +76,14 @@ pub struct Config {
     /// List review requests
     #[structopt(short, long)]
     review_requests: bool,
+
+    /// Sort by
+    #[structopt(short, long)]
+    sort_by: Option<Property>,
+
+    /// Ordering
+    #[structopt(short = "O", long)]
+    order: Option<Order>,
 
     /// Username
     ///
@@ -203,6 +219,10 @@ impl Config {
 
     pub fn pulls(&self) -> bool {
         self.pull_requests || self.all()
+    }
+
+    pub fn sorting(&self) -> Sorting {
+        Sorting(self.sort_by.unwrap_or_default(), self.order.unwrap_or_default())
     }
 
     pub fn label(&self) -> Vec<String> {

--- a/src/list.rs
+++ b/src/list.rs
@@ -3,11 +3,12 @@ use crate::{
     cfg::Config,
     issue::{Issue, Root},
     project::Project,
+    sort::Sorting,
     AppErr,
 };
 use crate::{
     project,
-    search::{GraphQLQuery, SearchIssues, SearchQuery, Sorting, Type},
+    search::{GraphQLQuery, SearchIssues, SearchQuery, Type},
 };
 use crate::{user::Username, Target};
 use core::fmt;
@@ -21,6 +22,7 @@ pub struct FilterConfig {
     issues: bool,
     labels: Vec<String>,
     project: Option<Project>,
+    sorting: Sorting,
     state: StateFilter,
     limit: u32,
 }
@@ -49,6 +51,7 @@ impl From<&Config> for FilterConfig {
             review_requests: cfg.reviews(),
             labels: cfg.label(),
             project: cfg.project(),
+            sorting: cfg.sorting(),
             issues: cfg.issues(),
             state: cfg.state(),
             limit: cfg.limit(),
@@ -117,7 +120,7 @@ fn create_query(kind: Type, user: &Option<String>, targets: &[Target], config: &
         assignee,
         resource_type: Some(kind),
         review_requested,
-        sort: (String::from("updated"), Sorting::Descending),
+        sort: config.sorting,
         state: config.state,
         labels: config.labels.clone(),
         project: config.project.clone(),

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,3 +1,4 @@
+use crate::search::{GraphQLQuery, SearchIssues, SearchQuery, Type};
 use crate::{
     api::ApiError,
     cfg::Config,
@@ -5,10 +6,6 @@ use crate::{
     project::Project,
     sort::Sorting,
     AppErr,
-};
-use crate::{
-    project,
-    search::{GraphQLQuery, SearchIssues, SearchQuery, Type},
 };
 use crate::{user::Username, Target};
 use core::fmt;
@@ -137,6 +134,7 @@ impl From<SendError<Issue>> for AppErr {
 
 impl From<ApiError> for AppErr {
     fn from(err: ApiError) -> Self {
+        log::error!("{:?}", err);
         match err {
             ApiError::NoResponse(_) => AppErr::ApiError,
             ApiError::Response(code) => match code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod list;
 mod logger;
 mod project;
 mod search;
+mod sort;
 mod target;
 mod ui;
 mod user;

--- a/src/project.rs
+++ b/src/project.rs
@@ -11,7 +11,7 @@ impl FromStr for Project {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split("/").collect();
+        let parts: Vec<&str> = s.split('/').collect();
         match parts.len() {
             2 => {
                 let owner: &str = parts.first().expect("Exactly two should be present");

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
-use crate::Target;
 use crate::{list::StateFilter, project::Project};
+use crate::{sort::Sorting, Target};
 use itertools::Itertools;
 use serde::Serialize;
 use serde_json::json;
@@ -10,21 +10,6 @@ pub struct GraphQLQuery {
     pub query: String,
     pub variables: serde_json::Value,
     pub operation_name: String,
-}
-
-pub enum Sorting {
-    Descending,
-    Ascending,
-}
-
-impl fmt::Display for Sorting {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let output: &str = match self {
-            Sorting::Ascending => "asc",
-            Sorting::Descending => "desc",
-        };
-        write!(f, "{}", output)
-    }
 }
 
 pub trait SearchQuery {
@@ -47,7 +32,7 @@ pub struct SearchIssues {
     pub project: Option<Project>,
     pub resource_type: Option<Type>,
     pub targets: Vec<Target>,
-    pub sort: (String, Sorting),
+    pub sort: Sorting,
     pub limit: u32,
 }
 
@@ -136,6 +121,6 @@ impl SearchIssues {
     }
 
     fn sort(&self) -> Option<String> {
-        Some(String::from("sort:updated-desc"))
+        Some(format!("sort:{}", self.sort))
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,9 +1,10 @@
 use crate::{list::StateFilter, project::Project};
 use crate::{sort::Sorting, Target};
 use itertools::Itertools;
+use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
-use std::fmt;
+use std::fmt::Display;
 
 #[derive(Serialize, Debug)]
 pub struct GraphQLQuery {
@@ -17,10 +18,22 @@ pub trait SearchQuery {
     fn build(&self) -> GraphQLQuery;
 }
 
+#[derive(Debug, Deserialize, Copy, Clone)]
 pub enum Type {
     Issue,
     PullRequest,
     ReviewRequest,
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let tp: &str = match self {
+            Type::Issue => "I",
+            Type::PullRequest => "P",
+            Type::ReviewRequest => "R",
+        };
+        write!(f, "{}", tp)
+    }
 }
 
 pub struct SearchIssues {
@@ -55,11 +68,11 @@ impl SearchQuery for SearchIssues {
             self.search_type(),
             self.state(),
             self.assignee(),
-            self.archived(),
+            Some(self.archived()),
             self.users(),
             self.labels(),
             self.project(),
-            self.sort(),
+            Some(self.sort()),
         ]
         .iter()
         .filter_map(|v| v.clone())
@@ -95,8 +108,8 @@ impl SearchIssues {
         }
     }
 
-    fn archived(&self) -> Option<String> {
-        Some(String::from("archived:false"))
+    fn archived(&self) -> String {
+        String::from("archived:false")
     }
 
     fn users(&self) -> Option<String> {
@@ -120,7 +133,7 @@ impl SearchIssues {
         self.project.clone().map(|p| format!("project:{}", p))
     }
 
-    fn sort(&self) -> Option<String> {
-        Some(format!("sort:{}", self.sort))
+    fn sort(&self) -> String {
+        format!("sort:{}", self.sort)
     }
 }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,6 +1,8 @@
-use std::{fmt, str::FromStr};
+use std::{cmp::Ordering, fmt, str::FromStr};
 
 use fmt::Display;
+
+use crate::issue::Issue;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Sorting(pub Property, pub Order);
@@ -11,12 +13,39 @@ impl Display for Sorting {
     }
 }
 
+impl Sorting {
+    pub fn sort(&self, i0: &Issue, i1: &Issue) -> Ordering {
+        let Sorting(prop, order) = self;
+        order.order(prop.sort(i0, i1))
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum Property {
     Created,
     Updated,
     Comments,
     Reactions,
+}
+
+impl Property {
+    pub fn sort(&self, i0: &Issue, i1: &Issue) -> Ordering {
+        match self {
+            Property::Created => i0.created_at.cmp(&i1.created_at),
+            Property::Updated => i0.updated_at.cmp(&i1.updated_at),
+            Property::Comments => i0.comments.total_count.cmp(&i1.comments.total_count),
+            Property::Reactions => i0.reactions.total_count.cmp(&i1.reactions.total_count),
+        }
+    }
+}
+
+impl Order {
+    pub fn order(&self, order: Ordering) -> Ordering {
+        match self {
+            Order::Ascending => order,
+            Order::Descending => order.reverse(),
+        }
+    }
 }
 
 impl Default for Property {

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,0 +1,86 @@
+use std::{fmt, str::FromStr};
+
+use fmt::Display;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Sorting(pub Property, pub Order);
+
+impl Display for Sorting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", self.0, self.1)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Property {
+    Created,
+    Updated,
+    Comments,
+    Reactions,
+}
+
+impl Default for Property {
+    fn default() -> Self {
+        Property::Updated
+    }
+}
+
+impl FromStr for Property {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "created" => Ok(Property::Created),
+            "updated" => Ok(Property::Updated),
+            "comments" => Ok(Property::Comments),
+            "reactions" => Ok(Property::Reactions),
+            _ => Err("Invalid property"),
+        }
+    }
+}
+
+impl Display for Property {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: &str = match self {
+            Property::Created => "created",
+            Property::Updated => "updated",
+            Property::Comments => "comments;",
+            Property::Reactions => "reactions",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Order {
+    Descending,
+    Ascending,
+}
+
+impl Default for Order {
+    fn default() -> Self {
+        Order::Descending
+    }
+}
+
+impl FromStr for Order {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "asc" | "ascending" => Ok(Order::Ascending),
+            "desc" | "descending" => Ok(Order::Descending),
+            _ => Err("Invalid sort order"),
+        }
+    }
+}
+
+impl fmt::Display for Order {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let output: &str = match self {
+            Order::Ascending => "asc",
+            Order::Descending => "desc",
+        };
+        write!(f, "{}", output)
+    }
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -29,22 +29,6 @@ impl FromStr for Target {
     }
 }
 
-impl Target {
-    fn org(&self) -> &String {
-        match self {
-            Target::Organization(org) => org,
-            Target::Repository(org, _) => org,
-        }
-    }
-
-    fn repo(&self) -> Option<&String> {
-        match self {
-            Target::Organization(_) => None,
-            Target::Repository(_, repo) => Some(repo),
-        }
-    }
-}
-
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
Enable sorting of issues and pull requests based on
- created at timestamp
- updated at timestamp
- number of comments
- number of reaction

All properties can be sorted both ascending and descending.

Closes #12 