### PR TITLE
Add annotation tokio::main to main function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ use tokio::runtime::Runtime;
 use ui::DisplayConfig;
 use user::Username;
 
-fn main() -> Result<(), AppErr> {
+#[tokio::main]
+async fn main() -> Result<(), AppErr> {
     let cfg: Config = Config::from_args();
 
     if cfg.print_debug() {


### PR DESCRIPTION
Add annotation tokio::main to main function so reqwest call for GitHub username request does not cause a crash.

Closes #28 