### PR TITLE
GitHub v4 API Only

### DIFF
--- a/data/graphql/queries/get_user.graphql
+++ b/data/graphql/queries/get_user.graphql
@@ -1,0 +1,6 @@
+query GetUser {
+  viewer {
+    login
+    id
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ use tokio::runtime::Runtime;
 use ui::DisplayConfig;
 use user::Username;
 
-fn main() -> Result<(), AppErr> {
+#[tokio::main]
+async fn main() -> Result<(), AppErr> {
     let cfg: Config = Config::from_args();
 
     if cfg.print_debug() {


### PR DESCRIPTION
Previously, the GitHub REST API (v3) was used instead of GitHub GraphQL API (v4) for fetching the username belonging to the supplied GitHub API token. With this change will only version 4 of the API be used.