### PR TITLE
fix(deps): remove vulnerable atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,23 +12,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,18 +142,49 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -209,12 +270,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -426,7 +487,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "structopt",
  "termcolor",
  "tokio",
 ]
@@ -458,21 +518,15 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -510,12 +564,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
@@ -674,6 +725,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,30 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,12 +974,6 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1230,44 +1274,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1349,15 +1358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1486,18 +1486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,22 +1504,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2"
-structopt = "0.3"
+clap = { version = "4.5", features = ["derive", "env"] }
 dirs-next = "1.0.2"
 itertools = "0.8"
 lazy_static = "1.4"
@@ -23,7 +22,7 @@ serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.8"
 log = "0.4"
-env_logger = "0.7"
+env_logger = "0.10"
 termcolor = "1.1"
 giro = "0.1"
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -9,11 +9,11 @@ use crate::{
     user::Username,
     AppErr,
 };
-use structopt::StructOpt;
+use clap::Parser;
 use termcolor::ColorChoice;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "giss", author, about)]
+#[derive(Parser, Debug)]
+#[command(name = "giss", author, about)]
 pub struct Config {
     /// Name of target(s)
     ///
@@ -26,86 +26,86 @@ pub struct Config {
     /// GitHub API token
     ///
     /// API token that will be used when authenticating towards GitHub's API
-    #[structopt(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<String>,
 
     /// Assigned only
     ///
     /// Only include issues and pull requests assigned to user
-    #[structopt(short, long)]
+    #[arg(short, long)]
     assigned: bool,
 
     /// Limit the number of issues or pull requests to list
-    #[structopt(short = "n", long, default_value = "10")]
+    #[arg(short = 'n', long, default_value = "10")]
     limit: u32,
 
     /// Show open issues or pull requests
     ///
     /// Include issues, pull request or review requests that are open. If neither this flag nor
     /// --closed/-c is given, default behavior will be to display open issues or pull requests.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     open: bool,
 
     /// Show closed issues or pull requests
     ///
     /// Include issues, pull request or review requests that are closed or merged
-    #[structopt(short, long)]
+    #[arg(short, long)]
     closed: bool,
 
     /// Filter by label
     ///
     /// Only include issues, pull requests or review reuests which has (all) the given label(s).
-    #[structopt(short, long)]
+    #[arg(short, long)]
     labels: Vec<String>,
 
     /// Filter by project
     ///
     /// Only include isses, pull request or review requests which is assoicated with the
     /// given project.
-    #[structopt(short = "P", long)]
+    #[arg(short = 'P', long)]
     project: Option<Project>,
 
     /// List issues
-    #[structopt(short, long)]
+    #[arg(short, long)]
     issues: bool,
 
     /// List pull requests
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pull_requests: bool,
 
     /// List review requests
-    #[structopt(short, long)]
+    #[arg(short, long)]
     review_requests: bool,
 
     /// Sort by
     ///
     /// Sort by any of the following properties; "created", "updated", "comments", "reactions"
-    #[structopt(short, long)]
+    #[arg(short, long)]
     sort_by: Option<Property>,
 
     /// Ordering
     ///
     /// Can be either ascending (asc|ascending) or decending (desc|descending)
-    #[structopt(short = "O", long)]
+    #[arg(short = 'O', long)]
     order: Option<Order>,
 
     /// Search
     ///
     /// Search by a string, which must be present either in the title or the body of an
     /// issue or pull request.
-    #[structopt(short = "S", long)]
+    #[arg(short = 'S', long)]
     search: Option<String>,
 
     /// Username
     ///
     /// Username to use for the query. Will default to the username for the user of the token.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     user: Option<Username>,
 
     /// Show links
     ///
     /// Show links to each issue or pull request in the output
-    #[structopt(short = "L", long)]
+    #[arg(short = 'L', long)]
     links: bool,
 
     /// Set use of colors
@@ -114,21 +114,21 @@ pub struct Config {
     /// try to figure out if colors are supported by the terminal in the current context, and use it
     /// if possible.
     /// Possible values are "on", "true", "off", "false", "auto".
-    #[structopt(long = "colors", default_value = "auto")]
+    #[arg(long = "colors", default_value = "auto")]
     colors: Flag,
 
     /// Set verbosity level, 0 - 5
     ///
     /// Set the verbosity level, from 0 (least amount of output) to 5 (most verbose). Note that
     /// logging level configured via RUST_LOG overrides this setting.
-    #[structopt(short, long, default_value = "1")]
+    #[arg(short, long, default_value = "1")]
     verbosity: Verbosity,
 
     /// Prind debug information
     ///
     /// Print debug information about current build for binary, useful for when an issue is
     /// encountered and reported
-    #[structopt(short = "D", long)]
+    #[arg(short = 'D', long)]
     debug: bool,
 }
 
@@ -152,7 +152,7 @@ impl FromStr for Flag {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Verbosity(u8);
 
 impl Verbosity {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ extern crate dirs_next;
 extern crate lazy_static;
 extern crate log;
 extern crate regex;
-extern crate structopt;
 
 mod api;
 mod args;
@@ -19,8 +18,8 @@ mod target;
 mod ui;
 mod user;
 
-use crate::structopt::StructOpt;
 use cfg::Config;
+use clap::Parser;
 use issue::Issue;
 use list::FilterConfig;
 use logger::setup_logging;
@@ -31,7 +30,7 @@ use user::Username;
 
 #[tokio::main]
 async fn main() -> Result<(), AppErr> {
-    let cfg: Config = Config::from_args();
+    let cfg: Config = Config::parse();
 
     if cfg.print_debug() {
         println!("{}", include_str!("../target/build_data"));


### PR DESCRIPTION
- Replaced unmaintained structopt/clap 2 with clap 4 derive.
- Updated env_logger to 0.10.
- Removed atty from the dependency graph.

Fixes GHSA-g98v-hv3f-hcfr.