### PR TITLE
feat(cli): add unassigned filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If the command is not invoked from a Git repository, an explicit repository will
 - `giss -c` - List only closed tickets in current repo
 - `giss -oc` - List both open and closed tickets in current repo
 - `giss -a` - List only open tickets assigned to user\* in current repo
+- `giss -U` - List only open tickets with no assignee in current repo
 - `giss -i` - List only open issues in current repo
 - `giss -p` - List only open pull requests in current repo
 - `giss -r` - List only review requests for user\*
@@ -82,6 +83,11 @@ FLAGS:
 
     -r, --review-requests
             List review requests
+
+    -U, --unassigned
+            Unassigned only
+
+            Only include issues, pull requests or review requests with no assignee
 
     -V, --version
             Prints version information

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -38,7 +38,7 @@ pub struct Config {
     /// Unassigned only
     ///
     /// Only include issues, pull requests or review requests with no assignee
-    #[structopt(short = "U", long, conflicts_with = "assigned")]
+    #[arg(short = 'U', long, conflicts_with = "assigned")]
     unassigned: bool,
 
     /// Limit the number of issues or pull requests to list
@@ -291,12 +291,16 @@ mod tests {
 
     #[test]
     fn parses_unassigned_short_and_long_flags() {
-        assert!(Config::from_iter(&["giss", "-U"]).unassigned_only());
-        assert!(Config::from_iter(&["giss", "--unassigned"]).unassigned_only());
+        assert!(Config::try_parse_from(["giss", "-U"])
+            .unwrap()
+            .unassigned_only());
+        assert!(Config::try_parse_from(["giss", "--unassigned"])
+            .unwrap()
+            .unassigned_only());
     }
 
     #[test]
     fn rejects_assigned_and_unassigned_together() {
-        assert!(Config::from_iter_safe(&["giss", "-a", "-U"]).is_err());
+        assert!(Config::try_parse_from(["giss", "-a", "-U"]).is_err());
     }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -274,3 +274,19 @@ impl Config {
         self.debug
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_unassigned_short_and_long_flags() {
+        assert!(Config::from_iter(&["giss", "-U"]).unassigned_only());
+        assert!(Config::from_iter(&["giss", "--unassigned"]).unassigned_only());
+    }
+
+    #[test]
+    fn rejects_assigned_and_unassigned_together() {
+        assert!(Config::from_iter_safe(&["giss", "-a", "-U"]).is_err());
+    }
+}

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -32,8 +32,14 @@ pub struct Config {
     /// Assigned only
     ///
     /// Only include issues and pull requests assigned to user
-    #[structopt(short, long)]
+    #[structopt(short, long, conflicts_with = "unassigned")]
     assigned: bool,
+
+    /// Unassigned only
+    ///
+    /// Only include issues, pull requests or review requests with no assignee
+    #[structopt(short = "U", long, conflicts_with = "assigned")]
+    unassigned: bool,
 
     /// Limit the number of issues or pull requests to list
     #[structopt(short = "n", long, default_value = "10")]
@@ -220,6 +226,10 @@ impl Config {
 
     pub fn assigned_only(&self) -> bool {
         self.assigned
+    }
+
+    pub fn unassigned_only(&self) -> bool {
+        self.unassigned
     }
 
     fn all(&self) -> bool {

--- a/src/list.rs
+++ b/src/list.rs
@@ -17,6 +17,7 @@ use std::{
 #[derive(Debug)]
 pub struct FilterConfig {
     assigned_only: bool,
+    unassigned_only: bool,
     pull_requests: bool,
     review_requests: bool,
     issues: bool,
@@ -48,6 +49,7 @@ impl From<&Config> for FilterConfig {
     fn from(cfg: &Config) -> Self {
         FilterConfig {
             assigned_only: cfg.assigned_only(),
+            unassigned_only: cfg.unassigned_only(),
             pull_requests: cfg.pulls(),
             review_requests: cfg.reviews(),
             labels: cfg.label(),
@@ -158,6 +160,7 @@ fn create_query(kind: Type, user: &Option<String>, targets: &[Target], config: &
     SearchIssues {
         archived: false,
         assignee,
+        unassigned: config.unassigned_only,
         resource_type: Some(kind),
         review_requested,
         sort: config.sorting,

--- a/src/search.rs
+++ b/src/search.rs
@@ -39,6 +39,7 @@ impl Display for Type {
 pub struct SearchIssues {
     pub state: StateFilter,
     pub assignee: Option<String>,
+    pub unassigned: bool,
     pub review_requested: Option<String>,
     pub archived: bool,
     pub labels: Vec<String>,
@@ -69,6 +70,7 @@ impl SearchQuery for SearchIssues {
             self.search_type(),
             self.state(),
             self.assignee(),
+            self.unassigned(),
             Some(self.archived()),
             self.users(),
             self.labels(),
@@ -108,6 +110,10 @@ impl SearchIssues {
             Some(name) => Some(format!("assignee:{}", name)),
             None => None,
         }
+    }
+
+    fn unassigned(&self) -> Option<String> {
+        self.unassigned.then(|| String::from("no:assignee"))
     }
 
     fn archived(&self) -> String {

--- a/src/search.rs
+++ b/src/search.rs
@@ -143,3 +143,33 @@ impl SearchIssues {
         self.search.clone().map(|s| format!("in:title,body {}", s))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sort::{Order, Property, Sorting};
+
+    #[test]
+    fn includes_no_assignee_qualifier_for_unassigned_searches() {
+        let query = SearchIssues {
+            state: StateFilter::Open,
+            assignee: None,
+            unassigned: true,
+            review_requested: None,
+            archived: false,
+            labels: vec![],
+            project: None,
+            resource_type: Some(Type::PullRequest),
+            targets: vec![],
+            sort: Sorting(Property::default(), Order::default()),
+            search: None,
+            limit: 10,
+        }
+        .build();
+
+        assert!(query.variables["searchQuery"]
+            .as_str()
+            .unwrap()
+            .contains("no:assignee"));
+    }
+}


### PR DESCRIPTION
Adds `-U` / `--unassigned`, applying GitHub’s `no:assignee` qualifier to issue, pull request, and review-request searches.

The new filter cannot be combined with `--assigned`. Includes parser and query tests plus README documentation.

Closes #60